### PR TITLE
Add provider meta module_name in Equinix Metal TF configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,10 +63,10 @@ The table below describes the variables included in the terraform.tfvars.templat
 
 |     Variable Name             |  Type   |    Default Value      | Description                                                               |
 | :---------------------------: | :-----: | :-------------------: | :------------------------------------------------------------------------ |
-|    metal_create_project       | bool    |        false          | Create a Equinix Metal Project if this is 'true'                          |
-|    metal_project_id           | string  |        n/a            | Equinix Metal Project ID. Required if 'metal_create_project' is 'false'   |
-|    metal_api_auth_token       | string  |        n/a            | Equinix Metal API Key                                                     |
-|    metal_device_metro         | string  |        "da"           | Equinix Metal metro location to deploy into. [More info](https://metal.equinix.com/developers/docs/locations/metros/#metros-quick-reference) |
+|    equinix_create_project     | bool    |        false          | Create a Equinix Metal Project if this is 'true'                          |
+|    equinix_project_id         | string  |        n/a            | Equinix Metal Project ID. Required if 'equinix_create_project' is 'false'   |
+|    equinix_api_auth_token     | string  |        n/a            | Equinix Metal API Key                                                     |
+|    equinix_device_metro       | string  |        "da"           | Equinix Metal metro location to deploy into. [More info](https://metal.equinix.com/developers/docs/locations/metros/#metros-quick-reference) |
 |    control_plane_plan         | string  |        "c3.small.x86" | Equinix Metal device type to deploy control plane nodes. [More info](https://metal.equinix.com/developers/docs/servers/server-specs/#current-generation) |
 |    data_plane_plan            | string  |        "c3.small.x86" | Equinix Metal device type to deploy data plane nodes. [More info](https://metal.equinix.com/developers/docs/servers/server-specs/#current-generation) |
 |    stack_name                 | string  |        n/a            | Equinix Metal server name prefix I.e., "ibm-satellite-equinix-metal"      |
@@ -110,7 +110,7 @@ Control_Plane_public_IPs = [
   "147.75.55.171",
   "147.75.55.211",
 ]
-Equinix_Metal_project_ID = "af5b81d0-789d-456g-9900-e3d4ec36fb04"
+Equinix_project_ID = "af5b81d0-789d-456g-9900-e3d4ec36fb04"
 SSH_key_location = "/home/ubuntu/.ssh/metal-ibm-satellite-prod-2x9hm"
 Worker_public_IPs = [
   "139.178.85.221",

--- a/ibm_satellite.tf
+++ b/ibm_satellite.tf
@@ -52,7 +52,7 @@ resource "ibm_satellite_host" "assign_host_cp" {
   ]
   location      = data.ibm_satellite_location.location.id
   cluster       = data.ibm_satellite_location.location.id
-  host_id       = metal_device.control_plane.*.hostname[count.index]
+  host_id       = equinix_metal_device.control_plane.*.hostname[count.index]
   zone          = element(var.ibm_sat_location_zones, count.index)
   host_provider = local.ibm_satellite_host_provider
 }

--- a/locals.tf
+++ b/locals.tf
@@ -1,7 +1,7 @@
 locals {
   stack_name                  = format("%s-%s", var.stack_name, random_string.cluster_suffix.result)
   ssh_key_name                = format("%s-key-%s", var.stack_name, random_string.cluster_suffix.result)
-  metal_project_id            = var.metal_create_project ? metal_project.new_project[0].id : var.metal_project_id
+  equinix_project_id            = var.equinix_create_project ? equinix_metal_project.new_project[0].id : var.equinix_project_id
   ibm_satellite_host_provider = "equinix"
 }
 

--- a/output.tf
+++ b/output.tf
@@ -1,10 +1,10 @@
 output "Control_Plane_public_IPs" {
-  value       = try(metal_device.control_plane.*.access_public_ipv4, "is not configured yet")
+  value       = try(equinix_metal_device.control_plane.*.access_public_ipv4, "is not configured yet")
   description = "Control Plane Public IPs"
 }
 
 output "Worker_public_IPs" {
-  value       = try(metal_device.data_plane.*.access_public_ipv4, "is not configured yet")
+  value       = try(equinix_metal_device.data_plane.*.access_public_ipv4, "is not configured yet")
   description = "Worker Node Public IPs"
 }
 
@@ -13,8 +13,8 @@ output "SSH_key_location" {
   description = "The SSH Private Key File Location"
 }
 
-output "Equinix_Metal_project_ID" {
-  value = local.metal_project_id
+output "Equinix_project_ID" {
+  value = local.equinix_project_id
   description = "The project ID used for this deployment"
 }
 

--- a/providers.tf
+++ b/providers.tf
@@ -1,5 +1,5 @@
-provider "metal" {
-  auth_token = var.metal_api_auth_token
+provider "equinix" {
+  auth_token = var.equinix_api_auth_token
 }
 
 provider "ibm" {

--- a/terraform.tfvars.template
+++ b/terraform.tfvars.template
@@ -1,7 +1,7 @@
-metal_create_project      = false
-metal_project_id          = // (string)
-metal_api_auth_token      = // (string)
-metal_device_metro        = "da" // YOU MIGHT CHOOSE A DIFFERENT EQUINIX METAL METRO LOCATION
+equinix_create_project      = false
+equinix_project_id          = // (string)
+equinix_api_auth_token      = // (string)
+equinix_device_metro        = "da" // YOU MIGHT CHOOSE A DIFFERENT EQUINIX METAL METRO LOCATION
 control_plane_plan        = "c3.small.x86" // YOU MIGHT CHOOSE A DIFFERENT SERVER SIZE
 data_plane_plan           = "c3.small.x86" // YOU MIGHT CHOOSE A DIFFERENT SERVER SIZE
 stack_name                = // (string) EQUINIX METAL SERVER NAME PREFIX I.e.: "ibm-satellite-equinix-metal"

--- a/variables.tf
+++ b/variables.tf
@@ -1,39 +1,39 @@
-variable metal_api_auth_token {
+variable equinix_api_auth_token {
   description = "Equinix Metal API Key"
   sensitive   = true
 }
 
-variable metal_create_project {
+variable equinix_create_project {
   type        = bool
   default     = true
-  description = "Create a Metal Project if this is 'true'. Else use provided 'metal_project_id'"
+  description = "Create a Metal Project if this is 'true'. Else use provided 'equinix_project_id'"
 }
 
-variable metal_project_name {
-  description = "The name of the project if 'metal_create_project' is 'true'."
+variable equinix_project_name {
+  description = "The name of the project if 'equinix_create_project' is 'true'."
   default     = "null"
 }
 
-variable metal_project_id {
+variable equinix_project_id {
   type        = string
   default     = "null"
-  description = "Equinix Metal Project ID. Required if 'metal_create_project' is 'false'"
+  description = "Equinix Metal Project ID. Required if 'equinix_create_project' is 'false'"
 }
 
-variable metal_organization_id {
+variable equinix_organization_id {
   type        = string
   default     = "null"
   description = "Equinix Metal Organization ID"
 }
 
-variable "metal_device_reservations" {
+variable "equinix_device_reservations" {
   description = <<-EOF
   A map of hostnames to reservation ids. Any hostname not defined will use the default behavior of not using a reservation.
   Mapped values may be UUIDs of the hardware reservations where you want these devices deployed,
   'next-available' if you want to pick your next available reservation automatically, or an empty string.
   Warning: Please be careful when using hardware reservation UUID and next-available together for the same pool of reservations.
   It might happen that the reservation which Equinix Metal API will pick as next-available is the reservation which you
-  refer with UUID in another metal_device resource. If that happens, and the metal_device with the UUID is created later,
+  refer with UUID in another equinix_device resource. If that happens, and the equinix_device with the UUID is created later,
   resource creation will fail because the reservation is already in use (by the resource created with next-available).
   Examples:
   - {"metal-ibm-sat-cp-01": "next-available"}
@@ -42,7 +42,7 @@ variable "metal_device_reservations" {
   type        = map(any)
   default     = {}
 }
-variable metal_device_metro {
+variable equinix_device_metro {
   description = "Equinix Metal metro location to deploy into"
   default     = "dc"
 }

--- a/versions.tf
+++ b/versions.tf
@@ -3,9 +3,9 @@ terraform {
     null = {
       source = "hashicorp/null"
     }
-    metal = {
-      source = "equinix/metal"
-      version = "2.1.0" 
+    equinix = {
+      source = "equinix/equinix"
+      version = "~> 1.14"
     }
     ibm = {
       source = "IBM-Cloud/ibm"
@@ -24,5 +24,7 @@ terraform {
       source = "hashicorp/local"
     }
   }
-  required_version = ">= 0.14"
+  provider_meta "equinix" {
+    module_name = "equinix-metal-ibm-satellite-on-baremetal"
+  }
 }


### PR DESCRIPTION
What this PR does / why we need it:
It allows Vendor to declare the metadata fields.  It adds  provider meta module_name in Equinix Metal TF configs


Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):

Related to https://github.com/equinix/terraform-provider-equinix/issues/252